### PR TITLE
Added feature for using the header module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,9 @@ categories = ["no-std"]
 
 [dependencies]
 bitflags = "1.2.1"
+
+[features]
+default = ["header"]
+
+# enables or disables the use of the header module
+header = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,9 @@ compile_error!("This crate only supports 64-bit architectures");
 #[macro_use]
 extern crate bitflags;
 
+#[cfg(feature = "header")]
 pub mod header;
+#[cfg(feature = "header")]
 pub use header::*;
 
 pub mod framebuffer;


### PR DESCRIPTION
The header module seems to be somewhat broken (I am getting an error
about how `function pointers cannot appear in constant functions`) so
I made it optional.